### PR TITLE
update action to use node16 to avoid warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: lock


### PR DESCRIPTION
to avoid warning
 Node.js 12 actions are deprecated. Please update the following actions to use Node.js